### PR TITLE
Add lang tag to html element

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
In order to fix this mistake, I found the html tag at the top of the document and added the lang tag for English. This is important to do because text on a webpage is not automatically read by a screen reader - it must be defined in the lang tag. 